### PR TITLE
JJP-135: Add login implementation in backend using JWT

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.DS_Store
+.idea/
+app/frontend/package-lock.json

--- a/auth_app/pom.xml
+++ b/auth_app/pom.xml
@@ -1,0 +1,17 @@
+<dependency>
+    <groupId>io.jsonwebtoken</groupId>
+    <artifactId>jjwt-api</artifactId>
+    <version>0.11.5</version>
+</dependency>
+<dependency>
+    <groupId>io.jsonwebtoken</groupId>
+    <artifactId>jjwt-impl</artifactId>
+    <version>0.11.5</version>
+    <scope>runtime</scope>
+</dependency>
+<dependency>
+    <groupId>io.jsonwebtoken</groupId>
+    <artifactId>jjwt-jackson</artifactId>
+    <version>0.11.5</version>
+    <scope>runtime</scope>
+</dependency>

--- a/auth_app/src/main/java/com.blankfactor.auth/config/AppConfig.java
+++ b/auth_app/src/main/java/com.blankfactor.auth/config/AppConfig.java
@@ -1,0 +1,51 @@
+package com.blankfactor.auth.config;
+
+import com.blankfactor.auth.repository.UserRepository;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.AuthenticationProvider;
+import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+
+@Slf4j
+public class AppConfig {
+
+    private final UserRepository userRepository;
+
+    public AppConfig(UserRepository userRepository) {
+        this.userRepository = userRepository;
+    }
+
+    @Bean
+    UserDetailsService userDetailsService() {
+        log.info("Initializing UserDetailsService bean.");
+        return identifier -> {
+            log.debug("Loading user by email or username: {}", identifier);
+            return userRepository.findByEmailOrUsername(identifier)
+                    .orElseThrow(() -> {
+                        log.warn("User not found with email: {}", identifier);
+                        return new UsernameNotFoundException("User not found");
+                    });
+        };
+    }
+
+    @Bean
+    public AuthenticationManager authenticationManager(AuthenticationConfiguration config) throws Exception {
+        log.info("Initializing AuthenticationManager bean.");
+        return config.getAuthenticationManager();
+    }
+
+    @Bean
+    AuthenticationProvider authenticationProvider() {
+        log.info("Initializing AuthenticationProvider bean.");
+        DaoAuthenticationProvider authProvider = new DaoAuthenticationProvider();
+
+        authProvider.setUserDetailsService(userDetailsService());
+        authProvider.setPasswordEncoder(passwordEncoder());
+
+        return authProvider;
+    }
+
+}

--- a/auth_app/src/main/java/com.blankfactor.auth/config/JwtAuthenticationFilter.java
+++ b/auth_app/src/main/java/com.blankfactor.auth/config/JwtAuthenticationFilter.java
@@ -1,0 +1,96 @@
+package com.blankfactor.auth.config;
+
+import com.blankfactor.auth.service.JwtService;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.JwtException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.NonNull;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+import org.springframework.web.servlet.HandlerExceptionResolver;
+
+import java.io.IOException;
+
+@Component
+@Slf4j
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final HandlerExceptionResolver handlerExceptionResolver;
+
+    private final JwtService jwtService;
+    private final UserDetailsService userDetailsService;
+
+    public JwtAuthenticationFilter(
+            JwtService jwtService,
+            UserDetailsService userDetailsService,
+            HandlerExceptionResolver handlerExceptionResolver
+    ) {
+        this.jwtService = jwtService;
+        this.userDetailsService = userDetailsService;
+        this.handlerExceptionResolver = handlerExceptionResolver;
+    }
+
+    @Override
+    protected void doFilterInternal(
+            @NonNull HttpServletRequest request,
+            @NonNull HttpServletResponse response,
+            @NonNull FilterChain filterChain
+    ) throws ServletException, IOException {
+        final String authHeader = request.getHeader("Authorization");
+
+        if (authHeader == null || !authHeader.startsWith("Bearer ")) {
+            log.debug("Authorization header is missing or invalid. Continuing without authentication.");
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        try {
+            final String jwt = authHeader.substring(7);
+            final String userEmail = jwtService.extractUsername(jwt);
+            log.debug("Extracted user email from JWT: {}", userEmail);
+
+            Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+            if (userEmail != null && authentication == null) {
+                UserDetails userDetails = this.userDetailsService.loadUserByUsername(userEmail);
+                log.debug("Loaded user details for email: {}", userEmail);
+                if (!jwtService.isTokenValid(jwt, userDetails)) {
+                    log.warn("JWT token is invalid for user: {}", userEmail);
+                    throw new JwtException("JWT token is invalid");
+                }
+
+                UsernamePasswordAuthenticationToken authToken = new UsernamePasswordAuthenticationToken(
+                        userDetails,
+                        null,
+                        userDetails.getAuthorities()
+                );
+
+                authToken.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+                SecurityContextHolder.getContext().setAuthentication(authToken);
+                log.debug("Set authentication context for user: {}", userEmail);
+            }
+
+            filterChain.doFilter(request, response);
+        } catch (ExpiredJwtException e) {
+            log.error("JWT token has expired.", e);
+            handlerExceptionResolver.resolveException(request, response, null, new ExpiredJwtException(null, null, "JWT token has expired"));
+        } catch (JwtException e) {
+            log.error("JWT token is invalid.", e);
+            handlerExceptionResolver.resolveException(request, response, null, new JwtException("JWT token is invalid"));
+        } catch (Exception e) {
+            log.error("An error occurred during JWT authentication.", e);
+            handlerExceptionResolver.resolveException(request, response, null, e);
+        }
+    }
+
+}

--- a/auth_app/src/main/java/com.blankfactor.auth/config/SecurityConfig.java
+++ b/auth_app/src/main/java/com.blankfactor.auth/config/SecurityConfig.java
@@ -1,0 +1,34 @@
+package com.blankfactor.auth.config;
+
+import com.blankfactor.auth.config.JwtAuthenticationFilter;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.AuthenticationProvider;
+import org.springframework.security.config.http.SessionCreationPolicy;
+
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@Slf4j
+public class SecurityConfig {
+
+    private final AuthenticationProvider authenticationProvider;
+    private final JwtAuthenticationFilter jwtAuthenticationFilter;
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        log.info("Configuring SecurityFilterChain.");
+        http
+                .csrf(csrf -> csrf.disable())
+                .authorizeHttpRequests(authorize -> authorize
+                        .requestMatchers("/api/v1/auth/**").permitAll()
+                        .anyRequest().authenticated()
+                )
+                .sessionManagement(session -> session
+                        .sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+                )
+                .authenticationProvider(authenticationProvider)
+                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
+        log.debug("SecurityFilterChain configured.");
+        return http.build();
+    }
+
+}

--- a/auth_app/src/main/java/com.blankfactor.auth/controller/AuthController.java
+++ b/auth_app/src/main/java/com.blankfactor.auth/controller/AuthController.java
@@ -1,0 +1,22 @@
+package com.blankfactor.auth.controller;
+
+import com.blankfactor.auth.entity.User;
+import com.blankfactor.auth.entity.dto.exp.LoginResponse;
+import com.blankfactor.auth.entity.dto.imp.LoginRequest;
+import com.blankfactor.auth.service.JwtService;
+
+
+public class AuthController {
+
+    private final JwtService jwtService;
+
+    @PostMapping("/login")
+    public ResponseEntity<LoginResponse> authenticate(@RequestBody LoginRequest loginRequest){
+        log.info("Authenticating user: {}", loginRequest.getLoginIdentifier());
+        User authenticatedUser = authService.login(loginRequest);
+        String jwtToken = jwtService.generateToken(authenticatedUser);
+        LoginResponse loginResponse = new LoginResponse(jwtToken, jwtService.getExpirationTime());
+        log.debug("Generated JWT token for user: {}", loginRequest.getLoginIdentifier());
+        return ResponseEntity.ok(loginResponse);
+    }
+}

--- a/auth_app/src/main/java/com.blankfactor.auth/controller/UserController.java
+++ b/auth_app/src/main/java/com.blankfactor.auth/controller/UserController.java
@@ -1,0 +1,39 @@
+package com.blankfactor.auth.controller;
+
+import com.blankfactor.auth.entity.User;
+import com.blankfactor.auth.entity.dto.exp.UserResponse;
+import com.blankfactor.auth.service.UserService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequestMapping("/api/v1/users")
+@RestController
+@RequiredArgsConstructor
+@Slf4j
+public class UserController {
+
+    private final UserService userService;
+
+    @GetMapping("/my-profile")
+    public ResponseEntity<UserResponse> getAuthenticatedUser() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        User currentUser = (User) authentication.getPrincipal();
+        log.info("Fetching authenticated user: {}", currentUser.getEmail());
+        UserResponse userResponse = new UserResponse(
+                currentUser.getEmail(),
+                currentUser.getUsername(),
+                currentUser.getFirstName(),
+                currentUser.getLastName(),
+                currentUser.getBirthDate()
+        );
+        log.debug("UserResponseDTO: {}", userResponse);
+        return ResponseEntity.ok(userResponse);
+    }
+
+}

--- a/auth_app/src/main/java/com.blankfactor.auth/entity/dto/exp/LoginResponse.java
+++ b/auth_app/src/main/java/com.blankfactor.auth/entity/dto/exp/LoginResponse.java
@@ -1,0 +1,18 @@
+package com.blankfactor.auth.entity.dto.exp;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class LoginResponse {
+
+    private String token;
+    private long expiresIn;
+
+    public LoginResponse(String token, long expiresIn) {
+        this.token = token;
+        this.expiresIn = expiresIn;
+    }
+
+}

--- a/auth_app/src/main/java/com.blankfactor.auth/entity/dto/exp/UserResponse.java
+++ b/auth_app/src/main/java/com.blankfactor.auth/entity/dto/exp/UserResponse.java
@@ -1,0 +1,19 @@
+package com.blankfactor.auth.entity.dto.exp;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@AllArgsConstructor
+public class UserResponse {
+
+    private String email;
+    private String username;
+    private String firstName;
+    private String lastName;
+    private LocalDateTime birthDate;
+}

--- a/auth_app/src/main/java/com.blankfactor.auth/entity/dto/imp/LoginRequest.java
+++ b/auth_app/src/main/java/com.blankfactor.auth/entity/dto/imp/LoginRequest.java
@@ -1,0 +1,14 @@
+package com.blankfactor.auth.entity.dto.imp;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@JsonIgnoreProperties(ignoreUnknown = false)
+public class LoginRequest {
+
+    private String loginIdentifier;
+    private String password;
+}

--- a/auth_app/src/main/java/com.blankfactor.auth/exception/GlobalExceptionHandler.java
+++ b/auth_app/src/main/java/com.blankfactor.auth/exception/GlobalExceptionHandler.java
@@ -1,0 +1,37 @@
+package com.blankfactor.auth.exception;
+
+import com.blankfactor.auth.exception.custom.InvalidPasswordException;
+import com.blankfactor.auth.exception.custom.PasswordsDoNotMatchException;
+import com.blankfactor.auth.exception.custom.VerificationEmailNotSentException;
+import com.blankfactor.auth.exception.custom.user.UserNotVerifiedException;
+
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.JwtException;
+
+
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler({
+            IncorrectVerificationCodeException.class,
+            PasswordsDoNotMatchException.class,
+            JwtException.class,
+            ExpiredJwtException.class,
+            IllegalArgumentException.class})
+    public ResponseEntity<Map<String, String>> handleCustomExceptions(RuntimeException ex) {
+        log.error("Handled exception: {} - {}", ex.getClass().getSimpleName(), ex.getMessage(), ex);
+        return new ResponseEntity<>(getErrorsMap("400", "BAD_REQUEST", ex.getMessage()), new HttpHeaders(), HttpStatus.BAD_REQUEST);
+    }
+
+    @ExceptionHandler(UserNotVerifiedException.class)
+    public ResponseEntity<Map<String, String>> handleUserNotVerifiedException(UserNotVerifiedException ex){
+        log.error("Handled exception: {} - {}", ex.getClass().getSimpleName(), ex.getMessage(), ex);
+        return new ResponseEntity<>(getErrorsMap("403", "FORBIDDEN", ex.getMessage()), new HttpHeaders(), HttpStatus.FORBIDDEN);
+    }
+
+    @ExceptionHandler(InvalidPasswordException.class)
+    public ResponseEntity<Map<String, String>> handleInvalidPasswordException(InvalidPasswordException ex) {
+        log.error("Handled exception: {} - {}", ex.getClass().getSimpleName(), ex.getMessage(), ex);
+        return new ResponseEntity<>(getErrorsMap("401", "UNAUTHORIZED", ex.getMessage()), new HttpHeaders(), HttpStatus.UNAUTHORIZED);
+    }
+
+}

--- a/auth_app/src/main/java/com.blankfactor.auth/exception/custom/InvalidPasswordException.java
+++ b/auth_app/src/main/java/com.blankfactor.auth/exception/custom/InvalidPasswordException.java
@@ -1,0 +1,7 @@
+package com.blankfactor.auth.exception.custom;
+
+public class InvalidPasswordException extends RuntimeException {
+    public InvalidPasswordException(String message) {
+        super(message);
+    }
+}

--- a/auth_app/src/main/java/com.blankfactor.auth/exception/custom/user/UserNotVerifiedException.java
+++ b/auth_app/src/main/java/com.blankfactor.auth/exception/custom/user/UserNotVerifiedException.java
@@ -1,0 +1,7 @@
+package com.blankfactor.auth.exception.custom.user;
+
+public class UserNotVerifiedException extends RuntimeException {
+    public UserNotVerifiedException(String message) {
+        super(message);
+    }
+}

--- a/auth_app/src/main/java/com.blankfactor.auth/repository/UserRepository.java
+++ b/auth_app/src/main/java/com.blankfactor.auth/repository/UserRepository.java
@@ -1,0 +1,10 @@
+package com.blankfactor.auth.repository;
+
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+
+    @Query("SELECT u FROM User u WHERE u.email = :identifier OR u.username = :identifier")
+    Optional<User> findByEmailOrUsername(@Param("identifier") String identifier);
+}

--- a/auth_app/src/main/java/com.blankfactor.auth/service/AuthService.java
+++ b/auth_app/src/main/java/com.blankfactor.auth/service/AuthService.java
@@ -1,0 +1,51 @@
+package com.blankfactor.auth.service;
+
+import com.blankfactor.auth.entity.dto.imp.LoginRequest;
+import com.blankfactor.auth.exception.custom.user.UserNotVerifiedException;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+
+public class AuthService {
+    private static final String USER_NOT_VERIFIED = "Account is not verified!";
+    private static final String INCORRECT_PASSWORD = "Incorrect password.";
+
+    private final AuthenticationManager authenticationManager;
+
+    public User login(LoginRequest input) {
+        if (input.getLoginIdentifier() == null || input.getLoginIdentifier().trim().isEmpty()) {
+            log.warn("Login identifier is null or empty");
+            throw new IllegalArgumentException("Login identifier cannot be null or empty");
+        }
+
+        log.info("Attempting to log in user with identifier: {}", input.getLoginIdentifier());
+
+        User user = userRepository.findByEmailOrUsername(input.getLoginIdentifier())
+                .orElseThrow(() -> {
+                    log.warn("User not found with identifier: {}", input.getLoginIdentifier());
+                    return new UserNotFoundException(USER_NOT_FOUND);
+                });
+
+        if (!user.isEnabled()) {
+            log.warn("User account is not verified: {}", input.getLoginIdentifier());
+            throw new UserNotVerifiedException(USER_NOT_VERIFIED);
+        }
+
+        try {
+            log.debug("Authenticating user credentials for: {}", input.getLoginIdentifier());
+            authenticationManager.authenticate(
+                    new UsernamePasswordAuthenticationToken(
+                            user.getEmail(),
+                            input.getPassword()
+                    )
+            );
+            log.info("User authenticated successfully: {}", input.getLoginIdentifier());
+        } catch (BadCredentialsException e) {
+            log.warn("Invalid password for user: {}", input.getLoginIdentifier());
+            throw new InvalidPasswordException(INCORRECT_PASSWORD);
+        }
+
+        log.debug("Returning user details for: {}", input.getLoginIdentifier());
+        return user;
+    }
+}

--- a/auth_app/src/main/java/com.blankfactor.auth/service/JwtService.java
+++ b/auth_app/src/main/java/com.blankfactor.auth/service/JwtService.java
@@ -1,0 +1,112 @@
+package com.blankfactor.auth.service;
+
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import java.security.Key;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Service;
+
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Function;
+
+@Service
+@Slf4j
+public class JwtService {
+
+    @Value("${security.jwt.secret-key}")
+    private String secretKey;
+
+    @Value("${security.jwt.expiration-time}")
+    private long jwtExpiration;
+
+    public String extractUsername(String token) {
+        log.debug("Extracting username from token.");
+        return extractClaim(token, Claims::getSubject);
+    }
+
+    public <T> T extractClaim(String token, Function<Claims, T> claimsResolver) {
+        log.debug("Extracting claim from token.");
+        final Claims claims = extractAllClaims(token);
+        return claimsResolver.apply(claims);
+    }
+
+    public String generateToken(UserDetails userDetails) {
+        log.debug("Generating token for user: {}", userDetails.getUsername());
+        return generateToken(new HashMap<>(), userDetails);
+    }
+
+    public String generateToken(Map<String, Object> extraClaims, UserDetails userDetails) {
+        log.debug("Generating token with extra claims for user: {}", userDetails.getUsername());
+        return buildToken(extraClaims, userDetails.getUsername(), jwtExpiration);
+    }
+
+    public long getExpirationTime() {
+        log.debug("Getting JWT expiration time.");
+        return jwtExpiration;
+    }
+
+    private String buildToken(
+            Map<String, Object> extraClaims,
+            String email,
+            long expiration
+    ) {
+        log.debug("Building token for user: {}", email);
+        return Jwts
+                .builder()
+                .setClaims(extraClaims)
+                .setSubject(email)
+                .setIssuedAt(new Date(System.currentTimeMillis()))
+                .setExpiration(new Date(System.currentTimeMillis() + expiration))
+                .signWith(getSignInKey(), SignatureAlgorithm.HS256)
+                .compact();
+    }
+
+    public boolean isTokenValid(String token, UserDetails userDetails) {
+        log.debug("Checking if token is valid for user: {}", userDetails.getUsername());
+        final String username = extractUsername(token);
+
+        if (!username.equals(userDetails.getUsername())) {
+            log.warn("Token does not belong to the authenticated user.");
+            throw new JwtException("Token does not belong to the authenticated user");
+        }
+
+        if (isTokenExpired(token)) {
+            log.warn("JWT token has expired.");
+            throw new ExpiredJwtException(null, null, "JWT token has expired");
+        }
+
+        return true;
+    }
+
+
+    private boolean isTokenExpired(String token) {
+        log.debug("Checking if token is expired.");
+        return extractExpiration(token).before(new Date());
+    }
+
+    private Date extractExpiration(String token) {
+        log.debug("Extracting expiration date from token.");
+        return extractClaim(token, Claims::getExpiration);
+    }
+
+    private Claims extractAllClaims(String token) {
+        return Jwts
+                .parserBuilder()
+                .setSigningKey(getSignInKey())
+                .build()
+                .parseClaimsJws(token)
+                .getBody();
+    }
+
+    private Key getSignInKey() {
+        log.debug("Generating sign-in key.");
+        byte[] keyBytes = Decoders.BASE64.decode(secretKey);
+        return Keys.hmacShaKeyFor(keyBytes);
+    }
+}

--- a/auth_app/src/main/resources/application.properties
+++ b/auth_app/src/main/resources/application.properties
@@ -1,0 +1,2 @@
+security.jwt.secret-key=${JWT_SECRET_KEY}
+security.jwt.expiration-time=3600000

--- a/auth_app/src/test/java/com.blankfactor.auth/controller/AuthControllerTest.java
+++ b/auth_app/src/test/java/com.blankfactor.auth/controller/AuthControllerTest.java
@@ -1,0 +1,127 @@
+package com.blankfactor.auth.controller;
+
+import com.blankfactor.auth.entity.User;
+import com.blankfactor.auth.entity.dto.imp.LoginRequest;
+import com.blankfactor.auth.exception.custom.InvalidPasswordException;
+import com.blankfactor.auth.exception.custom.user.UserNotVerifiedException;
+import com.blankfactor.auth.service.JwtService;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+public class AuthControllerTest {
+    private static final String LOGIN_ENDPOINT = "/api/v1/auth/login";
+
+    @MockitoBean
+    private JwtService jwtService;
+
+    @Nested
+    class LoginTests {
+
+        @Test
+        void shouldReturnLoginResponseForValidCredentials() throws Exception {
+            String loginRequestJson = """
+                    {
+                        "loginIdentifier": "test@example.com",
+                        "password": "password"
+                    }
+                    """;
+
+            User user = User.builder()
+                    .id(1L)
+                    .email("test@example.com")
+                    .username("testuser")
+                    .password("encodedPassword")
+                    .enabled(true)
+                    .build();
+
+            String jwtToken = "dummy.jwt.token";
+            long expirationTime = 3600000L;
+
+            when(authService.login(any(LoginRequest.class))).thenReturn(user);
+            when(jwtService.generateToken(any(User.class))).thenReturn(jwtToken);
+            when(jwtService.getExpirationTime()).thenReturn(expirationTime);
+
+            mockMvc.perform(post(LOGIN_ENDPOINT)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(loginRequestJson))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.token").value(jwtToken))
+                    .andExpect(jsonPath("$.expiresIn").value(expirationTime));
+        }
+
+        @Test
+        void shouldReturnNotFoundForNonExistentUser() throws Exception {
+            String loginRequestJson = """
+                    {
+                        "loginIdentifier": "nonexistent@example.com",
+                        "password": "password"
+                    }
+                    """;
+            String errorMessage = "nonexistent@example.com is not found";
+
+            when(authService.login(any(LoginRequest.class))).thenThrow(new UserNotFoundException(errorMessage));
+
+            mockMvc.perform(post(LOGIN_ENDPOINT)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(loginRequestJson))
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.message").value(errorMessage));
+        }
+
+        @Test
+        void shouldReturnUnauthorizedForInvalidPassword() throws Exception {
+            String loginRequestJson = """
+                    {
+                        "loginIdentifier": "test@example.com",
+                        "password": "wrongPassword"
+                    }
+                    """;
+            String errorMessage = "Incorrect password.";
+
+            when(authService.login(any(LoginRequest.class))).thenThrow(new InvalidPasswordException(errorMessage));
+
+            mockMvc.perform(post(LOGIN_ENDPOINT)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(loginRequestJson))
+                    .andExpect(status().isUnauthorized())
+                    .andExpect(jsonPath("$.message").value(errorMessage));
+        }
+
+        @Test
+        void shouldReturnForbiddenForUnverifiedUser() throws Exception {
+            String loginRequestJson = """
+                    {
+                        "loginIdentifier": "test@example.com",
+                        "password": "password"
+                    }
+                    """;
+            String errorMessage = "Account is not verified!";
+
+            when(authService.login(any(LoginRequest.class))).thenThrow(new UserNotVerifiedException(errorMessage));
+
+            mockMvc.perform(post(LOGIN_ENDPOINT)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(loginRequestJson))
+                    .andExpect(status().isForbidden())
+                    .andExpect(jsonPath("$.message").value(errorMessage));
+        }
+
+        @Test
+        void shouldReturnBadRequestForEmptyLoginIdentifier() throws Exception {
+            String loginRequestJson = """
+                    {
+                        "loginIdentifier": "",
+                        "password": "password"
+                    }
+                    """;
+            String errorMessage = "Login identifier cannot be null or empty";
+
+            when(authService.login(any(LoginRequest.class))).thenThrow(new IllegalArgumentException(errorMessage));
+
+            mockMvc.perform(post(LOGIN_ENDPOINT)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(loginRequestJson))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(content().string(org.hamcrest.Matchers.containsString(errorMessage)));
+        }
+    }
+}

--- a/auth_app/src/test/java/com.blankfactor.auth/controller/UserControllerTest.java
+++ b/auth_app/src/test/java/com.blankfactor.auth/controller/UserControllerTest.java
@@ -1,0 +1,75 @@
+package com.blankfactor.auth.controller;
+
+import com.blankfactor.auth.entity.User;
+import com.blankfactor.auth.service.UserService;
+import com.blankfactor.auth.service.JwtService;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalDateTime;
+
+import static org.hamcrest.Matchers.is;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@ExtendWith({MockitoExtension.class, SpringExtension.class})
+@WebMvcTest(controllers = UserController.class)
+public class UserControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private UserService userService;
+
+    @MockitoBean
+    private JwtService jwtService;
+
+    private User dummyUser;
+
+    private static final String USER_ENDPOINT = "/api/v1/users/my-profile";
+
+    @BeforeEach
+    void setUp() {
+        dummyUser = new User();
+        dummyUser.setId(1L);
+        dummyUser.setEmail("test@example.com");
+        dummyUser.setUsername("testuser");
+        dummyUser.setFirstName("Test");
+        dummyUser.setLastName("User");
+        dummyUser.setBirthDate(LocalDateTime.of(2000, 1, 1, 0, 0));
+        dummyUser.setEnabled(true);
+
+        UsernamePasswordAuthenticationToken authToken =
+                new UsernamePasswordAuthenticationToken(dummyUser, null, dummyUser.getAuthorities());
+        SecurityContextHolder.getContext().setAuthentication(authToken);
+    }
+
+    @AfterEach
+    void tearDown() {
+        SecurityContextHolder.clearContext();
+    }
+
+    @Test
+    void getAuthenticatedUser_shouldReturnUserResponse() throws Exception {
+        mockMvc.perform(get(USER_ENDPOINT)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.email", is(dummyUser.getEmail())))
+                .andExpect(jsonPath("$.username", is(dummyUser.getUsername())))
+                .andExpect(jsonPath("$.firstName", is(dummyUser.getFirstName())))
+                .andExpect(jsonPath("$.lastName", is(dummyUser.getLastName())))
+                .andExpect(jsonPath("$.birthDate", is(dummyUser.getBirthDate().toString() + ":00")));
+    }
+}

--- a/auth_app/src/test/java/com.blankfactor.auth/service/AuthServiceTest.java
+++ b/auth_app/src/test/java/com.blankfactor.auth/service/AuthServiceTest.java
@@ -1,0 +1,149 @@
+package com.blankfactor.auth.service;
+
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import com.blankfactor.auth.exception.custom.user.UserNotVerifiedException;
+import com.blankfactor.auth.exception.custom.InvalidPasswordException;
+import com.blankfactor.auth.entity.dto.imp.LoginRequest;
+
+@ExtendWith(MockitoExtension.class)
+public class AuthServiceTest {
+
+    @Mock
+    private AuthenticationManager authenticationManager;
+
+    @Nested
+    class LoginTests {
+        @Test
+        void loginWithValidEmailReturnsUser() {
+            LoginRequest loginRequest = new LoginRequest();
+            loginRequest.setLoginIdentifier(TEST_EMAIL);
+            loginRequest.setPassword("password");
+
+            User user = User.builder()
+                    .id(1L)
+                    .email(TEST_EMAIL)
+                    .username(TEST_USERNAME)
+                    .password("encodedPassword")
+                    .enabled(true)
+                    .build();
+
+            when(userRepository.findByEmailOrUsername(TEST_EMAIL))
+                    .thenReturn(Optional.of(user));
+
+            User result = authService.login(loginRequest);
+
+            assertNotNull(result);
+            assertEquals(user.getId(), result.getId());
+            assertEquals(user.getEmail(), result.getEmail());
+        }
+
+        @Test
+        void loginWithValidUsernameReturnsUser() {
+            LoginRequest loginRequest = new LoginRequest();
+            loginRequest.setLoginIdentifier(TEST_USERNAME);
+            loginRequest.setPassword("password");
+
+            User user = User.builder()
+                    .id(1L)
+                    .email(TEST_EMAIL)
+                    .username(TEST_USERNAME)
+                    .password("encodedPassword")
+                    .enabled(true)
+                    .build();
+
+            when(userRepository.findByEmailOrUsername(TEST_USERNAME))
+                    .thenReturn(Optional.of(user));
+
+            User result = authService.login(loginRequest);
+
+            assertNotNull(result);
+            assertEquals(user.getId(), result.getId());
+            assertEquals(user.getEmail(), result.getEmail());
+        }
+
+        @Test
+        void loginWithNonExistentUserThrowsUserNotFoundException() {
+            LoginRequest loginRequest = new LoginRequest();
+            loginRequest.setLoginIdentifier("nonexistent@example.com");
+            loginRequest.setPassword("password");
+
+            when(userRepository.findByEmailOrUsername("nonexistent@example.com"))
+                    .thenReturn(Optional.empty());
+
+            assertThrows(UserNotFoundException.class, () -> authService.login(loginRequest));
+        }
+
+        @Test
+        void loginWithUnverifiedUserThrowsUserNotVerifiedException() {
+            LoginRequest loginRequest = new LoginRequest();
+            loginRequest.setLoginIdentifier(TEST_EMAIL);
+            loginRequest.setPassword("password");
+
+            User user = User.builder()
+                    .id(2L)
+                    .email(TEST_EMAIL)
+                    .username(TEST_USERNAME)
+                    .password("encodedPassword")
+                    .enabled(false)
+                    .build();
+
+            when(userRepository.findByEmailOrUsername(TEST_EMAIL))
+                    .thenReturn(Optional.of(user));
+
+            Exception exception = assertThrows(UserNotVerifiedException.class, () -> authService.login(loginRequest));
+            assertTrue(exception.getMessage().contains("Account is not verified"));
+        }
+
+        @Test
+        void loginWithInvalidCredentialsThrowsInvalidPasswordException() {
+            LoginRequest loginRequest = new LoginRequest();
+            loginRequest.setLoginIdentifier(TEST_EMAIL);
+            loginRequest.setPassword("wrongPassword");
+
+            User user = User.builder()
+                    .id(3L)
+                    .email(TEST_EMAIL)
+                    .username(TEST_USERNAME)
+                    .password("encodedPassword")
+                    .enabled(true)
+                    .build();
+
+            when(userRepository.findByEmailOrUsername(TEST_EMAIL))
+                    .thenReturn(Optional.of(user));
+
+            when(authenticationManager.authenticate(any(UsernamePasswordAuthenticationToken.class)))
+                    .thenThrow(new BadCredentialsException("Bad credentials"));
+
+            assertThrows(InvalidPasswordException.class, () -> authService.login(loginRequest));
+        }
+
+        @Test
+        void loginWithNullIdentifierThrowsIllegalArgumentException() {
+            LoginRequest loginRequest = new LoginRequest();
+            loginRequest.setLoginIdentifier(null);
+            loginRequest.setPassword("password");
+
+            assertThrows(IllegalArgumentException.class, () -> authService.login(loginRequest));
+        }
+
+        @Test
+        void loginWithEmptyIdentifierThrowsIllegalArgumentException() {
+            LoginRequest loginRequest = new LoginRequest();
+            loginRequest.setLoginIdentifier("");
+            loginRequest.setPassword("password");
+
+            assertThrows(IllegalArgumentException.class, () -> authService.login(loginRequest));
+        }
+
+        @Test
+        void loginWithBlankIdentifierThrowsIllegalArgumentException() {
+            LoginRequest loginRequest = new LoginRequest();
+            loginRequest.setLoginIdentifier("   ");
+            loginRequest.setPassword("password");
+
+            assertThrows(IllegalArgumentException.class, () -> authService.login(loginRequest));
+        }
+    }
+}

--- a/auth_app/src/test/java/com.blankfactor.auth/service/JwtServiceTest.java
+++ b/auth_app/src/test/java/com.blankfactor.auth/service/JwtServiceTest.java
@@ -1,0 +1,88 @@
+package com.blankfactor.auth.service;
+
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.io.Encoders;
+import io.jsonwebtoken.security.Keys;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.security.core.userdetails.UserDetails;
+
+
+import javax.crypto.SecretKey;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class JwtServiceTest {
+
+    private JwtService jwtService;
+    private SecretKey secretKey;
+
+    private long jwtExpiration = 3600000L; // 1 hour
+
+    @BeforeEach
+    void setUp() {
+        secretKey = Keys.secretKeyFor(SignatureAlgorithm.HS256);
+        String base64SecretKey = Encoders.BASE64.encode(secretKey.getEncoded());
+        jwtService = new JwtService();
+
+        ReflectionTestUtils.setField(jwtService, "secretKey", base64SecretKey);
+        ReflectionTestUtils.setField(jwtService, "jwtExpiration", jwtExpiration);
+    }
+
+    @Test
+    void testGenerateAndExtractUsername() {
+        UserDetails userDetails = mock(UserDetails.class);
+        when(userDetails.getUsername()).thenReturn("testuser@example.com");
+
+        String token = jwtService.generateToken(userDetails);
+        assertNotNull(token, "Token should not be null");
+
+        String extractedUsername = jwtService.extractUsername(token);
+        assertEquals("testuser@example.com", extractedUsername, "Extracted username should match the one from UserDetails");
+    }
+
+    @Test
+    void testIsTokenValidSuccess() {
+        UserDetails userDetails = mock(UserDetails.class);
+        when(userDetails.getUsername()).thenReturn("testuser@example.com");
+
+        String token = jwtService.generateToken(userDetails);
+
+        boolean valid = jwtService.isTokenValid(token, userDetails);
+        assertTrue(valid, "Token should be valid for the same user");
+    }
+
+    @Test
+    void testIsTokenValidUserMismatch() {
+        UserDetails userDetails = mock(UserDetails.class);
+        when(userDetails.getUsername()).thenReturn("testuser@example.com");
+
+        String token = jwtService.generateToken(userDetails);
+
+        UserDetails otherUser = mock(UserDetails.class);
+        when(otherUser.getUsername()).thenReturn("otheruser@example.com");
+
+        assertThrows(JwtException.class, () -> jwtService.isTokenValid(token, otherUser),
+                "Token should not be valid for a different user");
+    }
+
+    @Test
+    void testTokenExpiration() {
+        ReflectionTestUtils.setField(jwtService, "jwtExpiration", -1000L);
+
+        UserDetails userDetails = mock(UserDetails.class);
+        when(userDetails.getUsername()).thenReturn("testuser@example.com");
+
+        String token = jwtService.generateToken(userDetails);
+
+        assertThrows(ExpiredJwtException.class, () -> jwtService.isTokenValid(token, userDetails),
+                "Expired token should throw ExpiredJwtException");
+    }
+}


### PR DESCRIPTION
JJP-135 link: https://blankfactor.atlassian.net/jira/software/projects/JJP/boards/116?selectedIssue=JJP-135

1. Integrated login functionality into the existing registration flow.
2. Reused and extended the user registration code for user authentication.
3. Implemented JWT token generation for authenticated users.
4. Added exception handling for invalid login credentials and token-related errors.
5. Updated AuthController to include a new /login endpoint for user authentication.
6. Added new UserController to verify authentication.
7. Improved global error handling for login-related issues.

